### PR TITLE
line 27 in tests

### DIFF
--- a/_tests_/array-methods.test.js
+++ b/_tests_/array-methods.test.js
@@ -7,7 +7,7 @@ const {
   firstWordLongerThan4Char,
   logValuesTimes3,
   logWordsWithExclamation,
-  arrayValuesTimes100TimesIndex,
+  arrayValuesSquaredTimesIndex,
   arrayWordsUpcased,
   areSomeNumsDivisibleBy7,
   doSomeWordsHaveAnA,
@@ -57,20 +57,20 @@ describe("Array Methods", () => {
   });
 
   test("Console log the values times 3", () => {
-    expect(/\.forEach/.test(logValuesTimes3.toString(nums))).toBe(true);
+    expect(/\.forEach/.test(logValuesTimes3.toString())).toBe(true);
     expect(logValuesTimes3(nums)).toBe(undefined);
   });
 
   test("Console log each word with an exclamation point", () => {
-    expect(/\.forEach/.test(logWordsWithExclamation.toString(words))).toBe(
+    expect(/\.forEach/.test(logWordsWithExclamation.toString())).toBe(
       true
     );
     expect(logWordsWithExclamation(words)).toBe(undefined);
   });
 
   test("A new array of values that are multiplied by their index number and 100", () => {
-    expect(/\.map/.test(arrayValuesTimes100TimesIndex.toString())).toBe(true);
-    expect(arrayValuesTimes100TimesIndex(nums)).toStrictEqual([
+    expect(/\.map/.test(arrayValuesSquaredTimesIndex.toString())).toBe(true);
+    expect(arrayValuesSquaredTimesIndex(nums)).toStrictEqual([
       0, 4, 18, 48, 100, 180, 294, 448, 648, 900, 0,
     ]);
   });

--- a/_tests_/array-methods.test.js
+++ b/_tests_/array-methods.test.js
@@ -24,7 +24,7 @@ describe("Array Methods", () => {
   });
 
   test("Every word is shorter than 7 characters", () => {
-    expect(/\.every/.test(isEveryWordShorterThan7().toString())).toBe(false);
+    expect(/\.every/.test(isEveryWordShorterThan7.toString())).toBe(true);
     expect(isEveryWordShorterThan7(words)).toBe(true);
   });
 

--- a/solution.js
+++ b/solution.js
@@ -41,7 +41,7 @@ const logWordsWithExclamation = () => {
 
 // Map
 
-const arrayValuesTimes100TimesIndex = () => {
+const arrayValuesSquaredTimesIndex = () => {
   //
 };
 

--- a/solution.js
+++ b/solution.js
@@ -68,7 +68,7 @@ module.exports = {
   firstWordLongerThan4Char,
   logValuesTimes3,
   logWordsWithExclamation,
-  arrayValuesTimes100TimesIndex,
+  arrayValuesSquaredTimesIndex,
   arrayWordsUpcased,
   areSomeNumsDivisibleBy7,
   doSomeWordsHaveAnA,


### PR DESCRIPTION
Hey Karolin! It seems there might be a mistake on line 27 in the test file? I believe this line is there to make sure that .every is used in the solution. isEveryWordShorterThan7 was originally invoked without an argument before having .toString called on it, which was causing a TypeError for people who had a parameter in their solution. It seems like several fellows got around this issue by just not setting up parameters in any of their functions and instead using the global "words" and "nums" variables directly in their solutions. 

I also changed "false" to be "true", since we **do** want .every to be used for the solution. With these two changes, line 27 now matches with all of the other similar tests, where the function to test is not invoked and the boolean is expected to be "true". 

I removed "words" and "nums" (both arrays) from being passed in as arguments for two .toString() calls on lines 60 and 65. I don't think they're causing any problems, but as far as I know .toString only takes an optional radix as an argument, which always has to be a number, so I figured those were probably typos. 

Let me know if these changes make sense or if I'm missing something/misunderstanding!

Any other changes are just to account for the name change from "arrayValuesTimes100TimesIndex" to "arrayValuesSquaredTimesIndex".